### PR TITLE
Update resolver to lts-7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,33 @@
-language: haskell
+language: c
+# GHC depends on GMP. You can add other dependencies here as well.
+dist: trusty
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+    - build-essential
+    - cmake
+    - git
 
 before_install:
-  - mkdir -p ~/.local/bin/stack
-  - export PATH=~/.local/bin/stack:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.4.3/stack-1.0.4.3-linux-x86_64.tar.gz | tar -xzf- -C ~/.local/bin/stack --strip-components=1
-  - chmod a+x ~/.local/bin/stack/stack
-  - cabal update
-  - cabal install happy
-  - cabal clean
-  - nvm install 5.9.0
-  - nvm use 5.9.0
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://ci.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - chmod a+x ~/.local/bin/stack
+  - nvm install 6.7.0
+  - nvm use 6.7.0
+
+env:
+- ISOLATED=true CACHE_NAME=LTS_7_1
 
 cache:
+  timeout: 1000
   directories:
-    - $HOME/.stack/
-
-install:
-  - stack setup --no-terminal
-  - stack build -j1 --only-dependencies --no-terminal
+    - $HOME/.stack
+    - $HOME/.ghcjs
 
 script:
-  - stack build -j1 --only-dependencies --no-terminal
+  - bash init.sh
+
 
 sudo: false

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+shopt -s expand_aliases
+
+export OLDPATH=$PATH
+
+alias stackjs='stack --stack-yaml stack.yaml'
+alias stack7='stack --stack-yaml stack-ghc.yaml'
+
+if [[ ! -f "$HOME/.stack/programs/x86_64-linux/ghc-8.0.1/bin/ghc-8.0.1" ]]; then
+echo "Rebuilding cache"
+stack7 setup --no-terminal
+stack7 install alex happy hscolour --no-terminal
+echo SETUP GHCJS
+stackjs setup --no-terminal
+
+PATH=$OLDPATH
+exit 0
+else
+
+echo "Reusing cache"
+
+fi
+
+stack7 install alex happy hscolour --no-terminal
+PATH=`stack7 path --bin-path 2>/dev/null`:$OLDPATH
+
+stackjs build -j1 --no-terminal
+
+PATH=$OLDPATH

--- a/reflex-starter.cabal
+++ b/reflex-starter.cabal
@@ -16,6 +16,9 @@ executable reflex-starter
   hs-source-dirs:      app
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghcjs >= 0.2.1)
+    ghcjs-options:     -dedupe
+
   build-depends:       base
                      , reflex >= 0.4.0
                      , reflex-dom >= 0.3

--- a/stack-ghc.yaml
+++ b/stack-ghc.yaml
@@ -1,0 +1,1 @@
+resolver: lts-7.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.18
+resolver: lts-7.1
 
 flags: {}
 
@@ -11,10 +11,14 @@ extra-deps:
 
 extra-package-dbs: []
 
-compiler: ghcjs-0.2.0.20160528_ghc-7.10.2
+compiler: ghcjs-0.2.1.9007001_ghc-8.0.1
 compiler-check: match-exact
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.0.20160528_ghc-7.10.2:
-        url: "http://ghcjs.luite.com/master-20160528.tar.gz"
+      ghcjs-0.2.1.9007001_ghc-8.0.1:
+          url: http://tolysz.org/ghcjs/ghc-8.0-2016-09-26-lts-7.1-9007001-mem.tar.gz
+          sha1: e640724883238593e2d2f7f03991cb413ec0347b
+
+allow-newer: true
+


### PR DESCRIPTION
Once we fix(choose) a resolver this configuration promotes quicker rebuilds. Currently one needs to restart(run) the build (one extra time) before it actually builds the project, but then it should be shared across builds.
There will be one cache bundle per resolver, thus make sure to purge them once you stop using them

[Run](https://api.travis-ci.org/jobs/163995344/log.txt?deansi=true)
